### PR TITLE
PALLADIO-503 Remove old StoEx Parser/Serialise/Utilities

### DIFF
--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomPassiveResourceEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomPassiveResourceEditPart.java
@@ -7,16 +7,20 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.PassiveResourceEditPart;
 import org.palladiosimulator.pcm.repository.PassiveResource;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.PassiveResourceEditPart;
 
 /**
  * A custom passive resource EditPart.
  */
 public class CustomPassiveResourceEditPart extends PassiveResourceEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * The changeListener.
      */
@@ -43,7 +47,11 @@ public class CustomPassiveResourceEditPart extends PassiveResourceEditPart {
         if (resolveSemanticElement() instanceof PassiveResource) {
             PassiveResource pr = (PassiveResource) resolveSemanticElement();
             if (pr.getCapacity_PassiveResource() != null) {
-                stoex = new PCMStoExPrettyPrintVisitor().prettyPrint(pr.getCapacity_PassiveResource().getExpression());
+                try {
+                    stoex = STOEX_SERIALISER.serialise(pr.getCapacity_PassiveResource().getExpression());
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise expression.", e);
+                }
             }
             text = pr.getEntityName();
             if (stoex == null) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomPassiveResourceEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomPassiveResourceEditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.repository.PassiveResource;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.PassiveResourceEditPart;
@@ -49,7 +50,7 @@ public class CustomPassiveResourceEditPart extends PassiveResourceEditPart {
             if (pr.getCapacity_PassiveResource() != null) {
                 try {
                     stoex = STOEX_SERIALISER.serialise(pr.getCapacity_PassiveResource().getExpression());
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise expression.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableCharacterisationEditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.VariableCharacterisationEditPart;
@@ -42,7 +43,7 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
             if (expression != null) {
                 try {
                     text += STOEX_SERIALISER.serialise(expression);
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise expression.", e);
                     text = null;
                 }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableCharacterisationEditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.VariableCharacterisationEditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.VariableCharacterisationEditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisationEditPart extends VariableCharacterisationEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * The constructor.
      * 
@@ -36,7 +40,12 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
             text = vc.getType().getLiteral() + " = ";
             Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
             if (expression != null) {
-                text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                try {
+                    text += STOEX_SERIALISER.serialise(expression);
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise expression.", e);
+                    text = null;
+                }
             }
         }
         if (text == null || text.length() == 0) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableUsageEditPart.java
@@ -7,15 +7,20 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
+import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.VariableUsageEditPart;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import de.uka.ipd.sdq.stoex.AbstractNamedReference;
 
 /**
  * A custom variable usage EditPart.
  */
 public class CustomVariableUsageEditPart extends VariableUsageEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * The constructor.
      *
@@ -62,9 +67,16 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
         private void createContents() {
 
             fFigureVariableUsageReferenceLabelFigure = this.getFigureVariableUsageReferenceLabelFigure();
-            if (resolveSemanticElement() != null) {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                .prettyPrint(((VariableUsage) resolveSemanticElement()).getNamedReference__VariableUsage()));
+            AbstractNamedReference reference = ((VariableUsage) resolveSemanticElement()).getNamedReference__VariableUsage();
+            String referenceText = null;
+            try {
+                referenceText = STOEX_SERIALISER.serialise(reference);
+            } catch (SerialisationErrorException e) {
+                Activator.getDefault().getLog().error("Could not serialise reference.", e);
+            }
+            
+            if (referenceText != null) {
+                fFigureVariableUsageReferenceLabelFigure.setText(referenceText);
             } else {
                 fFigureVariableUsageReferenceLabelFigure.setText("<null>");
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository.custom/src/de/uka/ipd/sdq/pcm/gmf/repository/custom/edit/parts/CustomVariableUsageEditPart.java
@@ -3,12 +3,13 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.parts.VariableUsageEditPart;
@@ -71,7 +72,7 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
             String referenceText = null;
             try {
                 referenceText = STOEX_SERIALISER.serialise(reference);
-            } catch (SerialisationErrorException e) {
+            } catch (NotSerializableException e) {
                 Activator.getDefault().getLog().error("Could not serialise reference.", e);
             }
             

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/PassiveResourceEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/PassiveResourceEditPart.java
@@ -3,6 +3,7 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.edit.parts;
 
+import java.io.NotSerializableException;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,7 +56,6 @@ import org.eclipse.swt.graphics.Image;
 import org.palladiosimulator.editors.commons.dialogs.repository.OpenCapacityDialog;
 import org.palladiosimulator.pcm.repository.PassiveResource;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PassiveResourceItemSemanticEditPolicy;
@@ -240,7 +240,7 @@ public class PassiveResourceEditPart extends CompartmentEditPart implements ITex
             if (pr.getCapacity_PassiveResource() != null) {
                 try {
                     stoex = STOEX_SERIALISER.serialise(pr.getCapacity_PassiveResource().getExpression());
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
                     .logError("Could not serialise expression.", e);
                 }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/PassiveResourceEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/PassiveResourceEditPart.java
@@ -52,22 +52,25 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
+import org.palladiosimulator.editors.commons.dialogs.repository.OpenCapacityDialog;
+import org.palladiosimulator.pcm.repository.PassiveResource;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PassiveResourceItemSemanticEditPolicy;
+import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelRepositoryDiagramEditorPlugin;
 import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelVisualIDRegistry;
 import de.uka.ipd.sdq.pcm.gmf.repository.providers.PalladioComponentModelElementTypes;
 import de.uka.ipd.sdq.pcm.gmf.repository.providers.PalladioComponentModelParserProvider;
-
-import org.palladiosimulator.editors.commons.dialogs.repository.OpenCapacityDialog;
-import org.palladiosimulator.pcm.repository.PassiveResource;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
 
 /**
  * @generated
  */
 public class PassiveResourceEditPart extends CompartmentEditPart implements ITextAwareEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * @generated
      */
@@ -235,7 +238,12 @@ public class PassiveResourceEditPart extends CompartmentEditPart implements ITex
         if (resolveSemanticElement() instanceof PassiveResource) {
             PassiveResource pr = (PassiveResource) resolveSemanticElement();
             if (pr.getCapacity_PassiveResource() != null) {
-                stoex = new PCMStoExPrettyPrintVisitor().prettyPrint(pr.getCapacity_PassiveResource().getExpression());
+                try {
+                    stoex = STOEX_SERIALISER.serialise(pr.getCapacity_PassiveResource().getExpression());
+                } catch (SerialisationErrorException e) {
+                    PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
+                    .logError("Could not serialise expression.", e);
+                }
             }
             text = pr.getEntityName();
             if (stoex == null) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableCharacterisationEditPart.java
@@ -48,16 +48,17 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
+import org.palladiosimulator.editors.commons.dialogs.OpenStoExDialog;
+import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.VariableCharacterisationItemSemanticEditPolicy;
+import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelRepositoryDiagramEditorPlugin;
 import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelVisualIDRegistry;
 import de.uka.ipd.sdq.pcm.gmf.repository.providers.PalladioComponentModelElementTypes;
 import de.uka.ipd.sdq.pcm.gmf.repository.providers.PalladioComponentModelParserProvider;
-
-import org.palladiosimulator.editors.commons.dialogs.OpenStoExDialog;
-import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -65,6 +66,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class VariableCharacterisationEditPart extends CompartmentEditPart implements ITextAwareEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * @generated
      */
@@ -234,7 +237,13 @@ public class VariableCharacterisationEditPart extends CompartmentEditPart implem
             text = vc.getType().getLiteral() + " = ";
             Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
             if (expression != null) {
-                text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                try {
+                    text += STOEX_SERIALISER.serialise(expression);
+                } catch (SerialisationErrorException e) {
+                    PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
+                        .logError("Could not serialise expression.", e);
+                    text = null;
+                }
             }
         }
         if (text == null || text.length() == 0) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableCharacterisationEditPart.java
@@ -3,6 +3,7 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.edit.parts;
 
+import java.io.NotSerializableException;
 import java.util.Collections;
 import java.util.List;
 
@@ -51,7 +52,6 @@ import org.eclipse.swt.graphics.Image;
 import org.palladiosimulator.editors.commons.dialogs.OpenStoExDialog;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.VariableCharacterisationItemSemanticEditPolicy;
@@ -239,7 +239,7 @@ public class VariableCharacterisationEditPart extends CompartmentEditPart implem
             if (expression != null) {
                 try {
                     text += STOEX_SERIALISER.serialise(expression);
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
                         .logError("Could not serialise expression.", e);
                     text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableUsageEditPart.java
@@ -30,18 +30,23 @@ import org.eclipse.gmf.runtime.gef.ui.figures.NodeFigure;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.gmf.tooling.runtime.edit.policies.reparent.CreationEditPolicyWithCustomReparent;
 import org.eclipse.swt.graphics.Color;
+import org.palladiosimulator.pcm.parameter.VariableUsage;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.VariableUsageItemSemanticEditPolicy;
+import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelRepositoryDiagramEditorPlugin;
 import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelVisualIDRegistry;
 import de.uka.ipd.sdq.pcm.gmf.repository.providers.PalladioComponentModelElementTypes;
-import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import de.uka.ipd.sdq.stoex.AbstractNamedReference;
 
 /**
  * @generated
  */
 public class VariableUsageEditPart extends ShapeNodeEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * @generated
      */
@@ -310,11 +315,18 @@ public class VariableUsageEditPart extends ShapeNodeEditPart {
          * @generated not
          */
         private void createContents() {
-
             fFigureVariableUsageReferenceLabelFigure = new WrapLabel();
-            if (resolveSemanticElement() != null) {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(((VariableUsage) resolveSemanticElement()).getNamedReference__VariableUsage()));
+            AbstractNamedReference reference = ((VariableUsage) resolveSemanticElement())
+                .getNamedReference__VariableUsage();
+            String referenceText = null;
+            try {
+                referenceText = STOEX_SERIALISER.serialise(reference);
+            } catch (SerialisationErrorException e) {
+                PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
+                    .logError("Could not serialise reference.", e);
+            }
+            if (referenceText != null) {
+                fFigureVariableUsageReferenceLabelFigure.setText(referenceText);
             } else {
                 fFigureVariableUsageReferenceLabelFigure.setText("<null>");
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.repository/src/de/uka/ipd/sdq/pcm/gmf/repository/edit/parts/VariableUsageEditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.repository.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridLayout;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.RectangleFigure;
@@ -32,7 +34,6 @@ import org.eclipse.gmf.tooling.runtime.edit.policies.reparent.CreationEditPolicy
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.repository.edit.policies.VariableUsageItemSemanticEditPolicy;
 import de.uka.ipd.sdq.pcm.gmf.repository.part.PalladioComponentModelRepositoryDiagramEditorPlugin;
@@ -321,7 +322,7 @@ public class VariableUsageEditPart extends ShapeNodeEditPart {
             String referenceText = null;
             try {
                 referenceText = STOEX_SERIALISER.serialise(reference);
-            } catch (SerialisationErrorException e) {
+            } catch (NotSerializableException e) {
                 PalladioComponentModelRepositoryDiagramEditorPlugin.getInstance()
                     .logError("Could not serialise reference.", e);
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomParametricResourceDemandEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomParametricResourceDemandEditPart.java
@@ -11,21 +11,25 @@ import org.eclipse.gmf.runtime.diagram.ui.editpolicies.EditPolicyRoles;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.LabelDirectEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.ListItemComponentEditPolicy;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.ParametricResourceDemandEditPart;
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.policies.ParametricResourceDemandItemSemanticEditPolicy;
-
 import org.palladiosimulator.editors.commons.dialogs.OpenStoExDialog;
 import org.palladiosimulator.pcm.seff.seff_performance.ParametricResourceDemand;
 import org.palladiosimulator.pcm.seff.seff_performance.SeffPerformancePackage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.ParametricResourceDemandEditPart;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.policies.PalladioComponentModelTextNonResizableEditPolicy;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.policies.ParametricResourceDemandItemSemanticEditPolicy;
+import de.uka.ipd.sdq.stoex.Expression;
 
 /**
  * The customized parametric resource demand edit part class.
  */
 public class CustomParametricResourceDemandEditPart extends ParametricResourceDemandEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     private static final int MAX_STOEX_DISPLAY_SIZE = 50;
 
     /** The change listener. */
@@ -86,8 +90,16 @@ public class CustomParametricResourceDemandEditPart extends ParametricResourceDe
         if (this.resolveSemanticElement() instanceof ParametricResourceDemand) {
             final ParametricResourceDemand demand = (ParametricResourceDemand) this.resolveSemanticElement();
             if (demand.getRequiredResource_ParametricResourceDemand() != null) {
-                text = new PCMStoExPrettyPrintVisitor().prettyPrint(demand.getSpecification_ParametericResourceDemand()
-                        .getExpression());
+                Expression expression = demand.getSpecification_ParametericResourceDemand()
+                        .getExpression();
+                try {
+                    text = STOEX_SERIALISER.serialise(expression);
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault()
+                        .getLog()
+                        .error("Could not serialise expression.", e);
+                    text = null;
+                }
                 if (text == null) {
                     text = "";
                 } else {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomParametricResourceDemandEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomParametricResourceDemandEditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EContentAdapter;
@@ -15,7 +17,6 @@ import org.palladiosimulator.editors.commons.dialogs.OpenStoExDialog;
 import org.palladiosimulator.pcm.seff.seff_performance.ParametricResourceDemand;
 import org.palladiosimulator.pcm.seff.seff_performance.SeffPerformancePackage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.ParametricResourceDemandEditPart;
@@ -94,7 +95,7 @@ public class CustomParametricResourceDemandEditPart extends ParametricResourceDe
                         .getExpression();
                 try {
                     text = STOEX_SERIALISER.serialise(expression);
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault()
                         .getLog()
                         .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation2EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation2EditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation2EditPart;
@@ -54,7 +55,7 @@ public class CustomVariableCharacterisation2EditPart extends VariableCharacteris
                 if (expression != null) {
                     try {
                         text += STOEX_SERIALISER.serialise(expression);
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault()
                             .getLog()
                             .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation2EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation2EditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation2EditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation2EditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisation2EditPart extends VariableCharacterisation2EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable characterisation2 edit part.
      * 
@@ -48,7 +52,14 @@ public class CustomVariableCharacterisation2EditPart extends VariableCharacteris
             if (vc.getSpecification_VariableCharacterisation() != null) {
                 final Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
                 if (expression != null) {
-                    text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                    try {
+                        text += STOEX_SERIALISER.serialise(expression);
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault()
+                            .getLog()
+                            .error("Could not serialise expression.", e);
+                        text = null;
+                    }
                 }
             } else {
                 text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation3EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation3EditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation3EditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation3EditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisation3EditPart extends VariableCharacterisation3EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable characterisation3 edit part.
      * 
@@ -48,7 +52,14 @@ public class CustomVariableCharacterisation3EditPart extends VariableCharacteris
             if (vc.getSpecification_VariableCharacterisation() != null) {
                 final Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
                 if (expression != null) {
-                    text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                    try {
+                        text += STOEX_SERIALISER.serialise(expression);
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault()
+                            .getLog()
+                            .error("Could not serialise expression.", e);
+                        text = null;
+                    }
                 }
             } else {
                 text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation3EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation3EditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation3EditPart;
@@ -54,7 +55,7 @@ public class CustomVariableCharacterisation3EditPart extends VariableCharacteris
                 if (expression != null) {
                     try {
                         text += STOEX_SERIALISER.serialise(expression);
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault()
                             .getLog()
                             .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation4EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation4EditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation4EditPart;
@@ -54,7 +55,7 @@ public class CustomVariableCharacterisation4EditPart extends VariableCharacteris
                 if (expression != null) {
                     try {
                         text += STOEX_SERIALISER.serialise(expression);
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault()
                             .getLog()
                             .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation4EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation4EditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation4EditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation4EditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisation4EditPart extends VariableCharacterisation4EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable characterisation4 edit part.
      * 
@@ -48,7 +52,14 @@ public class CustomVariableCharacterisation4EditPart extends VariableCharacteris
             if (vc.getSpecification_VariableCharacterisation() != null) {
                 final Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
                 if (expression != null) {
-                    text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                    try {
+                        text += STOEX_SERIALISER.serialise(expression);
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault()
+                            .getLog()
+                            .error("Could not serialise expression.", e);
+                        text = null;
+                    }
                 }
             } else {
                 text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation5EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation5EditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation5EditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation5EditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisation5EditPart extends VariableCharacterisation5EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable characterisation5 edit part.
      * 
@@ -48,7 +52,14 @@ public class CustomVariableCharacterisation5EditPart extends VariableCharacteris
             if (vc.getSpecification_VariableCharacterisation() != null) {
                 final Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
                 if (expression != null) {
-                    text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                    try {
+                        text += STOEX_SERIALISER.serialise(expression);
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault()
+                            .getLog()
+                            .error("Could not serialise expression.", e);
+                        text = null;
+                    }
                 }
             } else {
                 text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation5EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisation5EditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisation5EditPart;
@@ -54,7 +55,7 @@ public class CustomVariableCharacterisation5EditPart extends VariableCharacteris
                 if (expression != null) {
                     try {
                         text += STOEX_SERIALISER.serialise(expression);
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault()
                             .getLog()
                             .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisationEditPart.java
@@ -3,13 +3,14 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisationEditPart;
@@ -54,7 +55,7 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
                 if (expression != null) {
                     try {
                         text += STOEX_SERIALISER.serialise(expression);
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault()
                             .getLog()
                             .error("Could not serialise expression.", e);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableCharacterisationEditPart.java
@@ -7,10 +7,12 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisationEditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableCharacterisationEditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -18,6 +20,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisationEditPart extends VariableCharacterisationEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable characterisation edit part.
      * 
@@ -48,7 +52,14 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
             if (vc.getSpecification_VariableCharacterisation() != null) {
                 final Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
                 if (expression != null) {
-                    text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+                    try {
+                        text += STOEX_SERIALISER.serialise(expression);
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault()
+                            .getLog()
+                            .error("Could not serialise expression.", e);
+                        text = null;
+                    }
                 }
             } else {
                 text = null;

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage2EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage2EditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
@@ -12,7 +14,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage2EditPart;
@@ -83,7 +84,7 @@ public class CustomVariableUsage2EditPart extends VariableUsage2EditPart {
                 try {
                     fFigureVariableUsageReferenceLabelFigure
                         .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise reference.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage2EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage2EditPart.java
@@ -10,16 +10,20 @@ import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage2EditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage2EditPart;
 
 /**
  * The customized variable usage2 edit part class.
  */
 public class CustomVariableUsage2EditPart extends VariableUsage2EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
 
@@ -74,11 +78,14 @@ public class CustomVariableUsage2EditPart extends VariableUsage2EditPart {
             final WrappingLabel fFigureVariableUsageReferenceLabelFigure = this
                     .getFigureVariableUsageReferenceLabelFigure();
             VariableUsage variableUsage = (VariableUsage) resolveSemanticElement();
-            if (variableUsage == null) {
-                fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
-            } else {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(variableUsage.getNamedReference__VariableUsage()));
+            fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
+            if (variableUsage != null) {
+                try {
+                    fFigureVariableUsageReferenceLabelFigure
+                        .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                }
             }
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(CustomVariableUsage2EditPart.this
                     .getMapMode().DPtoLP(2), CustomVariableUsage2EditPart.this.getMapMode().DPtoLP(0),

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3EditPart.java
@@ -10,16 +10,20 @@ import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3EditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3EditPart;
 
 /**
  * The customized variable usage3 edit part class.
  */
 public class CustomVariableUsage3EditPart extends VariableUsage3EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
 
@@ -75,11 +79,14 @@ public class CustomVariableUsage3EditPart extends VariableUsage3EditPart {
             final WrappingLabel fFigureVariableUsageReferenceLabelFigure = this
                     .getFigureVariableUsageReferenceLabelFigure();
             VariableUsage variableUsage = (VariableUsage) resolveSemanticElement();
-            if (variableUsage == null) {
-                fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
-            } else {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(variableUsage.getNamedReference__VariableUsage()));
+            fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
+            if (variableUsage != null) {
+                try {
+                    fFigureVariableUsageReferenceLabelFigure
+                        .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                }
             }
 
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(CustomVariableUsage3EditPart.this

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3EditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
@@ -12,7 +14,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3EditPart;
@@ -84,7 +85,7 @@ public class CustomVariableUsage3EditPart extends VariableUsage3EditPart {
                 try {
                     fFigureVariableUsageReferenceLabelFigure
                         .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise reference.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3LabelEditPart.java
@@ -6,16 +6,20 @@ package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3LabelEditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3LabelEditPart;
 
 /**
  * The customized variable usage3 label edit part classw.
  */
 public class CustomVariableUsage3LabelEditPart extends VariableUsage3LabelEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable usage3 label edit part.
      * 
@@ -41,7 +45,12 @@ public class CustomVariableUsage3LabelEditPart extends VariableUsage3LabelEditPa
                 // customized
                 final VariableUsage usage = (VariableUsage) this.resolveSemanticElement();
                 if (usage.getNamedReference__VariableUsage() != null) {
-                    text = new PCMStoExPrettyPrintVisitor().prettyPrint(usage.getNamedReference__VariableUsage());
+                    try {
+                        text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                        text = null;
+                    }
                 }
             } else {
                 if (parserElement != null && this.getParser() != null) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage3LabelEditPart.java
@@ -3,12 +3,13 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage3LabelEditPart;
@@ -47,7 +48,7 @@ public class CustomVariableUsage3LabelEditPart extends VariableUsage3LabelEditPa
                 if (usage.getNamedReference__VariableUsage() != null) {
                     try {
                         text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault().getLog().error("Could not serialise reference.", e);
                         text = null;
                     }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4EditPart.java
@@ -11,16 +11,20 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4EditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4EditPart;
 
 /**
  * The customized variable usage4 edit part class.
  */
 public class CustomVariableUsage4EditPart extends VariableUsage4EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
 
@@ -75,11 +79,14 @@ public class CustomVariableUsage4EditPart extends VariableUsage4EditPart {
             final WrappingLabel fFigureVariableUsageReferenceLabelFigure = this
                     .getFigureVariableUsageReferenceLabelFigure();
             VariableUsage variableUsage = (VariableUsage) resolveSemanticElement();
-            if (variableUsage == null) {
-                fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
-            } else {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(variableUsage.getNamedReference__VariableUsage()));
+            fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
+            if (variableUsage != null) {
+                try {
+                    fFigureVariableUsageReferenceLabelFigure
+                        .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                }
             }
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(CustomVariableUsage4EditPart.this
                     .getMapMode().DPtoLP(2), CustomVariableUsage4EditPart.this.getMapMode().DPtoLP(0),

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4EditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
@@ -13,7 +15,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4EditPart;
@@ -84,7 +85,7 @@ public class CustomVariableUsage4EditPart extends VariableUsage4EditPart {
                 try {
                     fFigureVariableUsageReferenceLabelFigure
                         .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise reference.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4LabelEditPart.java
@@ -6,16 +6,20 @@ package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4LabelEditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4LabelEditPart;
 
 /**
  * The customized variable usage4 label edit part class.
  */
 public class CustomVariableUsage4LabelEditPart extends VariableUsage4LabelEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable usage4 label edit part.
      * 
@@ -41,7 +45,12 @@ public class CustomVariableUsage4LabelEditPart extends VariableUsage4LabelEditPa
                 // customized
                 final VariableUsage usage = (VariableUsage) this.resolveSemanticElement();
                 if (usage.getNamedReference__VariableUsage() != null) {
-                    text = new PCMStoExPrettyPrintVisitor().prettyPrint(usage.getNamedReference__VariableUsage());
+                    try {
+                        text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                        text = null;
+                    }
                 }
             } else {
                 if (parserElement != null && this.getParser() != null) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage4LabelEditPart.java
@@ -3,12 +3,13 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage4LabelEditPart;
@@ -47,7 +48,7 @@ public class CustomVariableUsage4LabelEditPart extends VariableUsage4LabelEditPa
                 if (usage.getNamedReference__VariableUsage() != null) {
                     try {
                         text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault().getLog().error("Could not serialise reference.", e);
                         text = null;
                     }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5EditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
@@ -13,7 +15,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5EditPart;
@@ -84,7 +85,7 @@ public class CustomVariableUsage5EditPart extends VariableUsage5EditPart {
                 try {
                     fFigureVariableUsageReferenceLabelFigure
                         .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise reference.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5EditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5EditPart.java
@@ -11,16 +11,20 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5EditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5EditPart;
 
 /**
  * The customized variable usage5 edit part class.
  */
 public class CustomVariableUsage5EditPart extends VariableUsage5EditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
 
@@ -75,11 +79,14 @@ public class CustomVariableUsage5EditPart extends VariableUsage5EditPart {
             final WrappingLabel fFigureVariableUsageReferenceLabelFigure = this
                     .getFigureVariableUsageReferenceLabelFigure();
             VariableUsage variableUsage = (VariableUsage) resolveSemanticElement();
-            if (variableUsage == null) {
-                fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
-            } else {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(variableUsage.getNamedReference__VariableUsage()));
+            fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
+            if (variableUsage != null) {
+                try {
+                    fFigureVariableUsageReferenceLabelFigure
+                        .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                }
             }
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(CustomVariableUsage5EditPart.this
                     .getMapMode().DPtoLP(2), CustomVariableUsage5EditPart.this.getMapMode().DPtoLP(0),

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5LabelEditPart.java
@@ -6,16 +6,20 @@ package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5LabelEditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5LabelEditPart;
 
 /**
  * The customized variable usage5 label edit part class.
  */
 public class CustomVariableUsage5LabelEditPart extends VariableUsage5LabelEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new customized variable usage5 label edit part.
      * 
@@ -40,7 +44,12 @@ public class CustomVariableUsage5LabelEditPart extends VariableUsage5LabelEditPa
                 // customized
                 final VariableUsage usage = (VariableUsage) this.resolveSemanticElement();
                 if (usage.getNamedReference__VariableUsage() != null) {
-                    text = new PCMStoExPrettyPrintVisitor().prettyPrint(usage.getNamedReference__VariableUsage());
+                    try {
+                        text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
+                    } catch (SerialisationErrorException e) {
+                        Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                        text = null;
+                    }
                 }
             } else {
                 if (parserElement != null && this.getParser() != null) {

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5LabelEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsage5LabelEditPart.java
@@ -3,12 +3,13 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsage5LabelEditPart;
@@ -46,7 +47,7 @@ public class CustomVariableUsage5LabelEditPart extends VariableUsage5LabelEditPa
                 if (usage.getNamedReference__VariableUsage() != null) {
                     try {
                         text = STOEX_SERIALISER.serialise(usage.getNamedReference__VariableUsage());
-                    } catch (SerialisationErrorException e) {
+                    } catch (NotSerializableException e) {
                         Activator.getDefault().getLog().error("Could not serialise reference.", e);
                         text = null;
                     }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsageEditPart.java
@@ -10,16 +10,20 @@ import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
-
-import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsageEditPart;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsageEditPart;
 
 /**
  * The customized variable usage edit part class.
  */
 public class CustomVariableUsageEditPart extends VariableUsageEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
 
@@ -74,11 +78,14 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
             final WrappingLabel fFigureVariableUsageReferenceLabelFigure = this
                     .getFigureVariableUsageReferenceLabelFigure();
             VariableUsage variableUsage = (VariableUsage) resolveSemanticElement();
-            if (variableUsage == null) {
-                fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
-            } else {
-                fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-                        .prettyPrint(variableUsage.getNamedReference__VariableUsage()));
+            fFigureVariableUsageReferenceLabelFigure.setText("<not set>");
+            if (variableUsage != null) {
+                try {
+                    fFigureVariableUsageReferenceLabelFigure
+                        .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
+                } catch (SerialisationErrorException e) {
+                    Activator.getDefault().getLog().error("Could not serialise reference.", e);
+                }
             }
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(CustomVariableUsageEditPart.this
                     .getMapMode().DPtoLP(2), CustomVariableUsageEditPart.this.getMapMode().DPtoLP(0),

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.custom/src/de/uka/ipd/sdq/pcm/gmf/seff/custom/edit/parts/CustomVariableUsageEditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.seff.custom.edit.parts;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
@@ -12,7 +14,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.seff.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.seff.edit.parts.VariableUsageEditPart;
@@ -83,7 +84,7 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
                 try {
                     fFigureVariableUsageReferenceLabelFigure
                         .setText(STOEX_SERIALISER.serialise(variableUsage.getNamedReference__VariableUsage()));
-                } catch (SerialisationErrorException e) {
+                } catch (NotSerializableException e) {
                     Activator.getDefault().getLog().error("Could not serialise reference.", e);
                 }
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.seff.helper/src/de/uka/ipd/sdq/pcm/gmf/seff/helper/StoExParser.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.seff.helper/src/de/uka/ipd/sdq/pcm/gmf/seff/helper/StoExParser.java
@@ -9,9 +9,11 @@ import org.eclipse.gmf.runtime.common.ui.services.parser.IParserEditStatus;
 import org.eclipse.gmf.runtime.common.ui.services.parser.ParserEditStatus;
 import org.eclipse.gmf.runtime.emf.type.core.commands.SetValueCommand;
 import org.eclipse.gmf.runtime.emf.type.core.requests.SetRequest;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
-import org.palladiosimulator.editors.commons.dialogs.stoex.StoExCompletionProcessor;
-import org.palladiosimulator.pcm.repository.Parameter;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
 
 import de.uka.ipd.sdq.stoex.Expression;
@@ -26,13 +28,6 @@ public class StoExParser implements IParser {
     protected static final org.palladiosimulator.pcm.stoex.api.StoExParser STOEX_PARSER = org.palladiosimulator.pcm.stoex.api.StoExParser.createInstance();
     protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.eclipse.gmf.runtime.common.ui.services.parser.IParser#getCompletionProcessor(org.eclipse
-     * .core.runtime.IAdaptable)
-     */
     /**
      * Gets the completion processor.
      * 
@@ -40,10 +35,46 @@ public class StoExParser implements IParser {
      *            the element
      * @return the completion processor
      * @see org.eclipse.gmf.runtime.common.ui.services.parser.IParser#getCompletionProcessor(org.eclipse.core.runtime.IAdaptable)
+     * @deprecated This method only returns a dummy {@link IContentAssistProcessor} that does not
+     *             provide any useful information when called. Clients should switch to Xtext-based
+     *             editors.
      */
     @Override
+    @Deprecated
     public IContentAssistProcessor getCompletionProcessor(final IAdaptable element) {
-        return new StoExCompletionProcessor(new Parameter[] {});
+        return new IContentAssistProcessor() {
+
+            @Override
+            public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
+                return new ICompletionProposal[0];
+            }
+
+            @Override
+            public IContextInformation[] computeContextInformation(ITextViewer viewer, int offset) {
+                return new IContextInformation[0];
+            }
+
+            @Override
+            public char[] getCompletionProposalAutoActivationCharacters() {
+                return new char[0];
+            }
+
+            @Override
+            public char[] getContextInformationAutoActivationCharacters() {
+                return new char[0];
+            }
+
+            @Override
+            public String getErrorMessage() {
+                return null;
+            }
+
+            @Override
+            public IContextInformationValidator getContextInformationValidator() {
+                return null;
+            }
+            
+        };
     }
 
     /*

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableCharacterisationEditPart.java
@@ -9,10 +9,12 @@ import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.gmf.runtime.diagram.ui.l10n.DiagramColorRegistry;
 import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
-
-import de.uka.ipd.sdq.pcm.gmf.usage.edit.parts.VariableCharacterisationEditPart;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
+import de.uka.ipd.sdq.pcm.gmf.usage.custom.Activator;
+import de.uka.ipd.sdq.pcm.gmf.usage.edit.parts.VariableCharacterisationEditPart;
 import de.uka.ipd.sdq.stoex.Expression;
 
 /**
@@ -20,6 +22,8 @@ import de.uka.ipd.sdq.stoex.Expression;
  */
 public class CustomVariableCharacterisationEditPart extends VariableCharacterisationEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * Instantiates a new custom variable characterisation edit part.
      * 
@@ -55,7 +59,12 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
         text = vc.getType().getLiteral() + " = ";
         Expression expression = vc.getSpecification_VariableCharacterisation().getExpression();
         if (expression != null) {
-            text += new PCMStoExPrettyPrintVisitor().prettyPrint(expression);
+            try {
+                text += STOEX_SERIALISER.serialise(expression);
+            } catch (SerialisationErrorException e) {
+                Activator.getDefault().getLog().error("Could not serialise expression.", e);
+                text = null;
+            }
         }
         if (text == null || text.length() == 0) {
             text = getLabelTextHelper(getFigure());

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableCharacterisationEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableCharacterisationEditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.usage.custom.edit.part;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EContentAdapter;
@@ -11,7 +13,6 @@ import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.View;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.usage.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.usage.edit.parts.VariableCharacterisationEditPart;
@@ -61,7 +62,7 @@ public class CustomVariableCharacterisationEditPart extends VariableCharacterisa
         if (expression != null) {
             try {
                 text += STOEX_SERIALISER.serialise(expression);
-            } catch (SerialisationErrorException e) {
+            } catch (NotSerializableException e) {
                 Activator.getDefault().getLog().error("Could not serialise expression.", e);
                 text = null;
             }

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableUsageEditPart.java
@@ -3,6 +3,8 @@
  */
 package de.uka.ipd.sdq.pcm.gmf.usage.custom.edit.part;
 
+import java.io.NotSerializableException;
+
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
@@ -10,7 +12,6 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.gmf.usage.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.usage.edit.parts.VariableUsageEditPart;
@@ -84,7 +85,7 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
             String referenceText = "<null>";
             try {
                 referenceText = STOEX_SERIALISER.serialise(reference);
-            } catch (SerialisationErrorException e) {
+            } catch (NotSerializableException e) {
                 Activator.getDefault().getLog().error("Could not serialise reference.", e);
             }
             fFigureVariableUsageReferenceLabelFigure.setText(referenceText);

--- a/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableUsageEditPart.java
+++ b/bundles/de.uka.ipd.sdq.pcm.gmf.usage.custom/src/de/uka/ipd/sdq/pcm/gmf/usage/custom/edit/part/CustomVariableUsageEditPart.java
@@ -9,15 +9,20 @@ import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.swt.graphics.Color;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
+import de.uka.ipd.sdq.pcm.gmf.usage.custom.Activator;
 import de.uka.ipd.sdq.pcm.gmf.usage.edit.parts.VariableUsageEditPart;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import de.uka.ipd.sdq.stoex.AbstractNamedReference;
 
 /**
  * The Class CustomVariableUsageEditPart.
  */
 public class CustomVariableUsageEditPart extends VariableUsageEditPart {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     // ATTENTION This value is likely to break. But there was no way to get access in parent.
     /** The Constant THIS_BACK. */
     static final Color THIS_BACK = new Color(null, 220, 220, 220);
@@ -75,8 +80,14 @@ public class CustomVariableUsageEditPart extends VariableUsageEditPart {
         private void createContents() {
 
             fFigureVariableUsageReferenceLabelFigure = getFigureVariableUsageReferenceLabelFigure();
-            fFigureVariableUsageReferenceLabelFigure.setText(new PCMStoExPrettyPrintVisitor()
-            .prettyPrint(((VariableUsage) resolveSemanticElement()).getNamedReference__VariableUsage()));
+            AbstractNamedReference reference = ((VariableUsage) resolveSemanticElement()).getNamedReference__VariableUsage();
+            String referenceText = "<null>";
+            try {
+                referenceText = STOEX_SERIALISER.serialise(reference);
+            } catch (SerialisationErrorException e) {
+                Activator.getDefault().getLog().error("Could not serialise reference.", e);
+            }
+            fFigureVariableUsageReferenceLabelFigure.setText(referenceText);
             fFigureVariableUsageReferenceLabelFigure.setBorder(new MarginBorder(getMapMode().DPtoLP(2), getMapMode()
                     .DPtoLP(0), getMapMode().DPtoLP(2), getMapMode().DPtoLP(0)));
         }


### PR DESCRIPTION
As requested by [PALLADIO-503](https://palladio-simulator.atlassian.net/browse/PALLADIO-503), I removed the hand-written StoEx parsers, serialisers and utilities and adjusted the code that used these classes.

This PR requires PalladioSimulator/Palladio-Core-PCM#31 to be merged before it compiles.